### PR TITLE
Pin IPython to 8.12 for Python 3.8 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ REQUIRED_PACKAGES = [
     'attrs',
     'bokeh >= 0.12.0',
     'intervaltree >= 2.1.0',
-    'IPython',
+    'IPython == 8.12',
     'librosa >= 0.6.2',
     'numpy',
     'pandas >= 0.18.1',


### PR DESCRIPTION
IPython published 8.13.0 which ended support for Python 3.8 so 8.12 needs to be pinned to continue Python 3.8 support.